### PR TITLE
Add projects for test helpers: serde tests and ScalaCheck Arbitrary

### DIFF
--- a/generators/app/templates/shared/.apidoc
+++ b/generators/app/templates/shared/.apidoc
@@ -8,4 +8,8 @@ code:
         play_2_4_client: play-client/src/main/generated
         kafka_0_8: kafka-lib_0_8/src/main/generated
         kafka_0_8_tests: kafka-lib_0_8/src/test/generated
+        kafka_0_9_serde: kafka-lib_0_9/src/main/generated
+        kafka_0_9_serde_test: kafka-lib_0_9/src/test/generated
         samza_serde: samza-lib/src/main/generated
+        samza_serde_test: samza-lib/src/test/generated
+        scalacheck_arbitrary: test-lib/src/main/generated

--- a/generators/app/templates/shared/build.sbt
+++ b/generators/app/templates/shared/build.sbt
@@ -11,7 +11,7 @@ val KafkaVersion_0_9 = "0.9.0.0"
 
 lazy val root = project
   .in( file(".") )
-  .aggregate(lib, playLib, kafkaLib_0_8, samzaLib)
+  .aggregate(lib, playLib, kafkaLib_0_8)
   .settings(
     publish := {}
   )
@@ -28,6 +28,7 @@ lazy val lib = project
 lazy val samzaLib = project
   .in(file("samza-lib"))
   .dependsOn(lib)
+  .dependsOn(testLib % Test)
   .aggregate(lib)
   .settings(commonSettings: _*)
   .settings(
@@ -35,9 +36,22 @@ lazy val samzaLib = project
     crossScalaVersions := Seq("2.10.4"),
     ivyScala := ivyScala.value map (_.copy(overrideScalaVersion = true)),
     libraryDependencies ++= Seq(
-      "com.typesafe.play" %% "play-ws" % PlayVersion,
+      "com.typesafe.play" %% "play-json" % PlayVersion,
       "org.apache.samza" % "samza-api" % SamzaVersion,
       "joda-time" % "joda-time" % "2.2"
+    )
+  )
+
+lazy val testLib = project
+  .in(file("test-lib"))
+  .dependsOn(lib)
+  .aggregate(lib)
+  .settings(commonSettings: _*)
+  .settings(
+    libraryDependencies ++= Seq(
+      "com.typesafe.play" %% "play-json" % PlayVersion,
+      "joda-time" % "joda-time" % "2.2",
+      "org.scalacheck" %% "scalacheck" % "1.12.5"
     )
   )
 
@@ -68,7 +82,19 @@ lazy val kafkaLib_0_8 = project
     )
   )
 
-// lazy val kafkaLib_0_8 = TBC
+lazy val kafkaLib_0_9 = project
+  .in(file("kafka-lib_0_9"))
+  .dependsOn(lib)
+  .dependsOn(testLib % Test)
+  .aggregate(lib)
+  .settings(commonSettings: _*)
+  .settings(
+    libraryDependencies ++= Seq(
+      "com.typesafe.play" %% "play-json" % PlayVersion,
+      "org.apache.kafka" % "kafka-clients" % KafkaVersion_0_9,
+      "joda-time" % "joda-time" % "2.9.1"
+    )
+  )
 
 
 lazy val commonSettings: Seq[Setting[_]] = Seq(

--- a/generators/app/templates/shared/test-lib/src/main/scala/movio/cinema/test/StandardArbitraries.scala
+++ b/generators/app/templates/shared/test-lib/src/main/scala/movio/cinema/test/StandardArbitraries.scala
@@ -1,0 +1,56 @@
+package movio.cinema.test
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen
+
+trait DateTimeArbitrary {
+  import org.joda.time._
+
+  implicit val arbLocalDateTime: Arbitrary[LocalDateTime] =
+    Arbitrary(Gen.posNum[Long] map (new LocalDateTime(_)))
+
+  implicit val arbDateTime: Arbitrary[DateTime] =
+    Arbitrary(Gen.posNum[Long] map (new DateTime(_)))
+}
+
+trait PlayJsonArbitrary {
+  import java.math.BigDecimal
+  import play.api.libs.json._
+  import Arbitrary.arbitrary
+  import Gen._
+
+  implicit val arbJsonObject: Arbitrary[JsObject] = Arbitrary(jsonObjectNode)
+  implicit val arbJsonArray: Arbitrary[JsArray] = Arbitrary(jsonArrayNode)
+
+  lazy val shortText: Gen[String] =
+    for {
+      n ← choose(0, 4)
+      chars ← listOfN(n, alphaNumChar)
+    } yield chars.mkString
+
+  lazy val jsonWholeNumberNode: Gen[JsNumber] = arbitrary[Long] map (n ⇒ JsNumber(new BigDecimal(n)))
+  lazy val jsonDecimalNumberNode: Gen[JsNumber]  = arbitrary[Double] map (n ⇒ JsNumber(new BigDecimal(n)))
+
+  lazy val jsonNumberNode: Gen[JsNumber] = oneOf(jsonWholeNumberNode, jsonDecimalNumberNode)
+  lazy val jsonStringNode: Gen[JsString] = shortText map JsString.apply
+  lazy val jsonBoolNode: Gen[JsBoolean] = oneOf(true, false) map JsBoolean.apply
+  lazy val jsonNullNode: Gen[JsNull.type] = const(JsNull)
+
+  lazy val jsonValueNode: Gen[JsValue] =
+    oneOf(jsonNumberNode, jsonStringNode, jsonBoolNode, jsonNullNode, jsonArrayNode, jsonObjectNode)
+
+  lazy val jsonArrayNode: Gen[JsArray] =
+    for {
+      n ← choose(1, 4)
+      values ← listOfN(n, jsonValueNode)
+    } yield JsArray(values)
+
+  lazy val jsonObjectNode: Gen[JsObject] =
+    for {
+      n ← choose(1, 4)
+      keys ← listOfN(n, shortText)
+      values ← listOfN(n, jsonValueNode)
+    } yield JsObject(keys zip values)
+}
+
+object StandardArbitraries extends DateTimeArbitrary with PlayJsonArbitrary


### PR DESCRIPTION
Cross reference movio/apidoc-generator#19
- Add default project for Kafka 0.9 serde and ScalaCheck Arbitrary
- Add tests to Kafka 0.9 serde and Samza serde libs
- Remove samzaLib as a default in root project
- Fix Play dependency from `-ws` to `-json`
